### PR TITLE
Updated 'learning-provider-created' 

### DIFF
--- a/eventing/events.json
+++ b/eventing/events.json
@@ -9,7 +9,7 @@
     "learning-provider-created": {
       "description": "New learning provider has been detected",
       "schema": {
-        "$ref": "#/definitions/learning-provider"
+        "$ref": "#/definitions/learning-provider-event"
       }
     },
     "learning-provider-updated": {


### PR DESCRIPTION
It looks like an earlier commit added point in time information, but only updated the 'learning-provider-created' event!

This commit upgrades the 'learning-provider-created' event schema to include the same & hopefully allowing the event broker to pass it's schema validation checks! 